### PR TITLE
added support for CES.getMedia() in tspci-qbci

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   "node": true,
-  "esnext": true,
+  "esversion": 11,
   "bitwise": true,
   "camelcase": true,
   "curly": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   "node": true,
-  "esversion": 11,
+  "esnext": true,
   "bitwise": true,
   "camelcase": true,
   "curly": true,

--- a/lib/tspci-qbci/package.json
+++ b/lib/tspci-qbci/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "types": "types/index.d.ts",
   "dependencies": {
+    "chalk": "5.3.0",
     "archiver": "^7.0.1"
   },
   "scripts": {},

--- a/lib/tspci-qbci/src/createPackage.mjs
+++ b/lib/tspci-qbci/src/createPackage.mjs
@@ -1,6 +1,8 @@
+"use strict";
 import fs, { mkdirSync } from "fs";
 import path from "path";
 import archiver from "archiver";
+import chalk from "chalk";
 
 export const bundle = () => {
   const PACKAGE_ROOT_PATH = process.cwd();
@@ -84,7 +86,10 @@ export const bundle = () => {
   if (!fs.existsSync(scriptPath)) {
     fs.mkdirSync(scriptPath);
   }
-  fs.copyFileSync(path.join(PACKAGE_ROOT_PATH, pciFile), path.join(scriptPath, "/index.min.js"));
+  const minifiedFilePath = path.join(scriptPath, "/index.min.js");
+  const maxJsFileSize = 499; // the facet player has a limit of 500kb for js files
+  fs.copyFileSync(path.join(PACKAGE_ROOT_PATH, pciFile), minifiedFilePath);
+  isMaxFileSize(maxJsFileSize, minifiedFilePath);
 
   // zip the folder
   const zipName = `${name}_${packageData.version}.ci`;
@@ -93,6 +98,19 @@ export const bundle = () => {
     console.log(`created questify ci zip: ${zipName}`)
   );
 };
+
+function isMaxFileSize(maxFileSize, filePath){
+  const fileSizeInBytes = fs.statSync(filePath).size;
+  const fileSizeInKilobytes = (fileSizeInBytes / 1024).toFixed(2);
+  if (parseFloat(fileSizeInKilobytes) > maxFileSize){
+    // js file to big
+    console.log(chalk.red(`❗️Warning, minified file size of ${maxFileSize}kb exceeded: ${fileSizeInKilobytes} KB.❗️`));
+    console.log(chalk.red(`This will result in a packagestream error in the player.`));
+  }else{
+    // js file is ok
+    console.log(`✅ minified js file size: ${fileSizeInKilobytes} KB (max: ${maxFileSize} KB)`);
+  }
+}
 
 function copyDirectoryRecursiveSync(source, target) {
   if (!fs.lstatSync(source).isDirectory() || source.endsWith("tmp")) return;

--- a/lib/tspci-qbci/src/createPackage.mjs
+++ b/lib/tspci-qbci/src/createPackage.mjs
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 import fs, { mkdirSync } from "fs";
 import path from "path";
 import archiver from "archiver";
@@ -89,6 +89,21 @@ export const bundle = () => {
   const minifiedFilePath = path.join(scriptPath, "/index.min.js");
   const maxJsFileSize = 499; // the facet player has a limit of 500kb for js files
   fs.copyFileSync(path.join(PACKAGE_ROOT_PATH, pciFile), minifiedFilePath);
+
+  // make changes to the manifest.json
+  // add media files to manifest.json and copy them to the output directory
+  const manifestRaw = fs.readFileSync(path.join(outputDirectoryTemp, 'ref/json/manifest.json'), 'utf8');
+  let manifestData = JSON.parse(manifestRaw);
+  const assetsFolderPath = path.join(PACKAGE_ROOT_PATH, 'assets');
+  const media = getMediaPathFilesArray(assetsFolderPath);
+  if (media.length > 0) {
+    manifestData = {...manifestData, media};
+    fs.writeFileSync(path.join(outputDirectoryTemp, 'ref/json/manifest.json'), JSON.stringify(manifestData), 'utf8');
+    copyDirectoryRecursiveSync(assetsFolderPath, path.join(outputDirectoryTemp, 'ref/media'));
+
+    findAndReplaceStringInFile(minifiedFilePath, 'assets/', 'ref/media/');
+  }
+
   isMaxFileSize(maxJsFileSize, minifiedFilePath);
 
   // zip the folder
@@ -98,6 +113,38 @@ export const bundle = () => {
     console.log(`created questify ci zip: ${zipName}`)
   );
 };
+
+function findAndReplaceStringInFile(file, oldStr, newStr){
+  // open minifiedFilePath and search and replace 'assets/' with 'ref/media/'
+  let fileContent = fs.readFileSync(file, 'utf8');
+  const count = (fileContent.match(new RegExp(oldStr, 'g')) || []).length;
+  fileContent = fileContent.replace(oldStr, 'ref/media/');
+  fs.writeFileSync(file, fileContent, 'utf8');
+  // how many times the string was replaced
+  console.log(`✅ replaced ${oldStr} ${count} times with ${newStr} in ${file}`);
+}
+
+function getMediaPathFilesArray(assetsFolderPath){
+  if (!fs.existsSync(assetsFolderPath)) {
+    console.log(chalk.orange(`Assets folder not found: ${assetsFolderPath}`));
+    return [];
+  }
+
+  const mediaFiles = [];
+  const files = fs.readdirSync(assetsFolderPath);
+
+  files.forEach(file => {
+    // check if file is an image, if not skip
+    if (!file.match(/\.(png|jpe?g|gif|svg)$/)) {
+     return;
+    }
+
+    const filePath = `ref/media/${file}`;
+    mediaFiles.push(filePath);
+  });
+
+  return mediaFiles;
+}
 
 function isMaxFileSize(maxFileSize, filePath){
   const fileSizeInBytes = fs.statSync(filePath).size;

--- a/lib/tspci-qbci/src/createPackage.mjs
+++ b/lib/tspci-qbci/src/createPackage.mjs
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 import fs, { mkdirSync } from "fs";
 import path from "path";
 import archiver from "archiver";
@@ -42,7 +42,7 @@ export const bundle = () => {
   const questifyMetadataData = JSON.parse(rawMetadata);
 
   const propertiesToReplace = {
-    typeIdentifier: "emptytypeIdentifier"
+    typeIdentifier: "emptytypeIdentifier",
   };
   copyDirectoryRecursiveSync(path.join(PACKAGER_PATH, "questify-default"), outputDirectoryTemp, false);
 
@@ -56,13 +56,13 @@ export const bundle = () => {
     if (propertyName === "typeIdentifier") {
       if (!packageData.config?.tspci[propertyName]) {
         console.error(
-          "'typeIdentifier' should be added as an option in package.json and should match the typeIdentifier of the PCI code file."
+          "'typeIdentifier' should be added as an option in package.json and should match the typeIdentifier of the PCI code file.",
         );
         return;
       } else {
         if (!packageData.config?.tspci[propertyName])
           console.info(
-            `${propertyName} not specified in ${packageData.name} in package.json using { config: tspci: {${propertiesToReplace[propertyName]}}`
+            `${propertyName} not specified in ${packageData.name} in package.json using { config: tspci: {${propertiesToReplace[propertyName]}}`,
           );
       }
     }
@@ -90,18 +90,24 @@ export const bundle = () => {
   const maxJsFileSize = 499; // the facet player has a limit of 500kb for js files
   fs.copyFileSync(path.join(PACKAGE_ROOT_PATH, pciFile), minifiedFilePath);
 
-  // make changes to the manifest.json
+  // make changes to the if files found in ./assets in the root of the project
   // add media files to manifest.json and copy them to the output directory
-  const manifestRaw = fs.readFileSync(path.join(outputDirectoryTemp, 'ref/json/manifest.json'), 'utf8');
-  let manifestData = JSON.parse(manifestRaw);
-  const assetsFolderPath = path.join(PACKAGE_ROOT_PATH, 'assets');
+  // replace 'assets/' with 'ref/media/' in the minified js file
+  const assetsFolderPath = path.join(PACKAGE_ROOT_PATH, "assets");
   const media = getMediaPathFilesArray(assetsFolderPath);
   if (media.length > 0) {
-    manifestData = {...manifestData, media};
-    fs.writeFileSync(path.join(outputDirectoryTemp, 'ref/json/manifest.json'), JSON.stringify(manifestData), 'utf8');
-    copyDirectoryRecursiveSync(assetsFolderPath, path.join(outputDirectoryTemp, 'ref/media'));
+    const manifestRaw = fs.readFileSync(path.join(outputDirectoryTemp, "ref/json/manifest.json"), "utf8");
+    let manifestData = JSON.parse(manifestRaw);
+    manifestData = { ...manifestData, media };
 
-    findAndReplaceStringInFile(minifiedFilePath, 'assets/', 'ref/media/');
+    // check if ref/media folder exists, if not create it
+    const mediaPath = path.join(outputDirectoryTemp, "ref/media");
+    if (!fs.existsSync(mediaPath)) {
+      fs.mkdirSync(mediaPath);
+    }
+
+    fs.writeFileSync(path.join(outputDirectoryTemp, "ref/json/manifest.json"), JSON.stringify(manifestData), "utf8");
+    copyDirectoryRecursiveSync(assetsFolderPath, path.join(outputDirectoryTemp, "ref/media"));
   }
 
   isMaxFileSize(maxJsFileSize, minifiedFilePath);
@@ -110,21 +116,11 @@ export const bundle = () => {
   const zipName = `${name}_${packageData.version}.ci`;
   zipDirectory(outputDirectoryTemp, path.join(outputDirectory, zipName)).then(() =>
     // fs.rmdirSync(outputDirectoryTemp, { recursive: true });
-    console.log(`created questify ci zip: ${zipName}`)
+    console.log(`created questify ci zip: ${zipName}`),
   );
 };
 
-function findAndReplaceStringInFile(file, oldStr, newStr){
-  // open minifiedFilePath and search and replace 'assets/' with 'ref/media/'
-  let fileContent = fs.readFileSync(file, 'utf8');
-  const count = (fileContent.match(new RegExp(oldStr, 'g')) || []).length;
-  fileContent = fileContent.replace(oldStr, 'ref/media/');
-  fs.writeFileSync(file, fileContent, 'utf8');
-  // how many times the string was replaced
-  console.log(`✅ replaced ${oldStr} ${count} times with ${newStr} in ${file}`);
-}
-
-function getMediaPathFilesArray(assetsFolderPath){
+function getMediaPathFilesArray(assetsFolderPath) {
   if (!fs.existsSync(assetsFolderPath)) {
     console.log(chalk.orange(`Assets folder not found: ${assetsFolderPath}`));
     return [];
@@ -133,10 +129,10 @@ function getMediaPathFilesArray(assetsFolderPath){
   const mediaFiles = [];
   const files = fs.readdirSync(assetsFolderPath);
 
-  files.forEach(file => {
+  files.forEach((file) => {
     // check if file is an image, if not skip
     if (!file.match(/\.(png|jpe?g|gif|svg)$/)) {
-     return;
+      return;
     }
 
     const filePath = `ref/media/${file}`;
@@ -146,14 +142,14 @@ function getMediaPathFilesArray(assetsFolderPath){
   return mediaFiles;
 }
 
-function isMaxFileSize(maxFileSize, filePath){
+function isMaxFileSize(maxFileSize, filePath) {
   const fileSizeInBytes = fs.statSync(filePath).size;
   const fileSizeInKilobytes = (fileSizeInBytes / 1024).toFixed(2);
-  if (parseFloat(fileSizeInKilobytes) > maxFileSize){
+  if (parseFloat(fileSizeInKilobytes) > maxFileSize) {
     // js file to big
     console.log(chalk.red(`❗️Warning, minified file size of ${maxFileSize}kb exceeded: ${fileSizeInKilobytes} KB.❗️`));
     console.log(chalk.red(`This will result in a packagestream error in the player.`));
-  }else{
+  } else {
     // js file is ok
     console.log(`✅ minified js file size: ${fileSizeInKilobytes} KB (max: ${maxFileSize} KB)`);
   }
@@ -164,8 +160,8 @@ function copyDirectoryRecursiveSync(source, target) {
   // var operation = move ? fs.renameSync : fs.copyFileSync;
   fs.readdirSync(source).forEach(function (itemName) {
     if (!(itemName.indexOf("questify-pci-") !== -1 && itemName.indexOf(".zip") !== -1)) {
-      var sourcePath = path.join(source, itemName);
-      var targetPath = path.join(target, itemName);
+      const sourcePath = path.join(source, itemName);
+      const targetPath = path.join(target, itemName);
       if (fs.lstatSync(sourcePath).isDirectory()) {
         if (!fs.existsSync(targetPath) && !targetPath.toLocaleLowerCase().endsWith("tmp")) {
           fs.mkdirSync(targetPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,20 @@
       "name": "@citolab/tspci-qbci",
       "version": "2.5.4",
       "dependencies": {
-        "archiver": "^7.0.1"
+        "archiver": "^7.0.1",
+        "chalk": "5.3.0"
+      }
+    },
+    "lib/tspci-qbci/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "lib/tspci-tao": {
@@ -538,20 +551,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@citolab/pci-verhoudingen": {
-      "resolved": "pcis/tspci-color-proportions",
-      "link": true
-    },
     "node_modules/@citolab/preact-store": {
       "resolved": "lib/preact-store",
       "link": true
     },
     "node_modules/@citolab/tspci": {
       "resolved": "lib/tspci",
-      "link": true
-    },
-    "node_modules/@citolab/tspci-3d-blocks": {
-      "resolved": "pcis/tspci-3d-blocks",
       "link": true
     },
     "node_modules/@citolab/tspci-qbci": {
@@ -1951,49 +1956,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@react-hook/event": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
-      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@react-hook/latest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
-      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@react-hook/mouse-position": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/mouse-position/-/mouse-position-4.1.3.tgz",
-      "integrity": "sha512-+N4X75CmFiZVEySVmz54MkHk68FqKbbBG2rMCSbGSCCFdypV7rAHiatZwx9Ruq/XfQ01XCxBPaLNMiW69mY19Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-hook/event": "^1.2.6",
-        "@react-hook/throttle": "^2.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@react-hook/throttle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
-      "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-hook/latest": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
     "node_modules/@rollup/plugin-alias": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
@@ -2680,13 +2642,6 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
-    },
-    "node_modules/@types/three": {
-      "version": "0.136.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
-      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -5106,10 +5061,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/demo-pci": {
-      "resolved": "pcis/demoPCI",
-      "link": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8770,19 +8721,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -9485,10 +9423,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "node_modules/my-pci-three": {
-      "resolved": "pcis/myPciThree",
-      "link": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -11181,6 +11115,7 @@
       "version": "10.24.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.0.tgz",
       "integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -11422,19 +11357,6 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -13384,22 +13306,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/three": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
-      "integrity": "sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A==",
-      "license": "MIT"
-    },
-    "node_modules/three-orbitcontrols": {
-      "version": "2.110.3",
-      "resolved": "https://registry.npmjs.org/three-orbitcontrols/-/three-orbitcontrols-2.110.3.tgz",
-      "integrity": "sha512-BNNbksJwbN3/MmT0X/gjz5ZCchm7bjk26SUdtJYRxfEYjDfkb/0PeUTHE/KuyJ5vb/owK3mojyy3vcqDx99sRA==",
-      "deprecated": "three-js exposes real modules now via three/examples/jsm/...\nfor example to import Orbit, do\nimport { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'\n",
-      "license": "MIT",
-      "peerDependencies": {
-        "three": ">= 0.110.0"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -14337,103 +14243,9 @@
     "pcis/demoPCI": {
       "name": "demo-pci",
       "version": "1.0.0",
+      "extraneous": true,
       "devDependencies": {
         "@citolab/tspci": "latest"
-      }
-    },
-    "pcis/demoPCI/node_modules/@citolab/tspci": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.2.tgz",
-      "integrity": "sha512-y+YyOv4J9j5tEgL2eIfTxmlo8i9ucJ4aA+Hnxjj5jkc9fq6mSFSjSYX/W91VUOcgE6E3ge2hNm8oi44Mx1gTzQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/plugin-alias": "^5.1.0",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^26.0.1",
-        "@rollup/plugin-image": "^3.0.3",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^5.0.7",
-        "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "^11.1.6",
-        "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-        "@testing-library/dom": "^10.4.0",
-        "@types/node": "^22.5.5",
-        "@typescript-eslint/eslint-plugin": "^8.5.0",
-        "@typescript-eslint/parser": "^8.5.0",
-        "autoprefixer": "10.4.20",
-        "chalk": "5.3.0",
-        "clear": "0.1.0",
-        "figlet": "1.7.0",
-        "inquirer": "11.0.1",
-        "live-server": "^1.2.2",
-        "postcss": "^8.4.47",
-        "postcss-import": "^16.1.0",
-        "rollup": "^4.21.3",
-        "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-live-server": "^2.0.0",
-        "rollup-plugin-node-builtins": "^2.1.2",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-string": "^3.0.0",
-        "rollup-plugin-watch-assets": "^1.0.1",
-        "tailwindcss": "^3.4.11"
-      },
-      "bin": {
-        "tspci": "src/cli.js"
-      }
-    },
-    "pcis/demoPCI/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "pcis/demoPCI/node_modules/inquirer": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-      "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.2.1",
-        "@inquirer/prompts": "^6.0.1",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "pcis/demoPCI/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "pcis/demoPCI/node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "pcis/jozo": {
@@ -14558,6 +14370,7 @@
     },
     "pcis/myPciThree": {
       "name": "my-pci-three",
+      "extraneous": true,
       "dependencies": {
         "@citolab/preact-store": "latest",
         "preact": "^10.13.2"
@@ -14568,218 +14381,6 @@
         "autoprefixer": "10.4.14",
         "postcss-import": "^15.1.0",
         "tailwindcss": "^3.3.2"
-      }
-    },
-    "pcis/myPciThree/node_modules/@citolab/preact-store": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-      "license": "MIT",
-      "peerDependencies": {
-        "preact": ">= 10.0.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/@citolab/tspci": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/plugin-alias": "^5.1.0",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^26.0.1",
-        "@rollup/plugin-image": "^3.0.3",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^5.0.7",
-        "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "^11.1.6",
-        "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-        "@testing-library/dom": "^10.4.0",
-        "@types/node": "^22.5.5",
-        "@typescript-eslint/eslint-plugin": "^8.5.0",
-        "@typescript-eslint/parser": "^8.5.0",
-        "autoprefixer": "10.4.20",
-        "chalk": "5.3.0",
-        "clear": "0.1.0",
-        "figlet": "1.7.0",
-        "inquirer": "11.0.1",
-        "live-server": "^1.2.2",
-        "postcss": "^8.4.47",
-        "postcss-import": "^16.1.0",
-        "rollup": "^4.21.3",
-        "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-live-server": "^2.0.0",
-        "rollup-plugin-node-builtins": "^2.1.2",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-string": "^3.0.0",
-        "rollup-plugin-watch-assets": "^1.0.1",
-        "tailwindcss": "^3.4.11"
-      },
-      "bin": {
-        "tspci": "src/cli.js"
-      }
-    },
-    "pcis/myPciThree/node_modules/@citolab/tspci/node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/@citolab/tspci/node_modules/postcss-import": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-      "integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "pcis/myPciThree/node_modules/inquirer": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-      "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.2.1",
-        "@inquirer/prompts": "^6.0.1",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "pcis/myPciThree/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "pcis/myPciThree/node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "pcis/myPciTypescript": {
@@ -14849,6 +14450,7 @@
     },
     "pcis/tspci-3d-blocks": {
       "name": "@citolab/tspci-3d-blocks",
+      "extraneous": true,
       "dependencies": {
         "@citolab/preact-store": "latest",
         "preact": "10.6.4",
@@ -14862,200 +14464,9 @@
         "autoprefixer": "10.4.13"
       }
     },
-    "pcis/tspci-3d-blocks/node_modules/@citolab/preact-store": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-      "license": "MIT",
-      "peerDependencies": {
-        "preact": ">= 10.0.0"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/@citolab/tspci": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/plugin-alias": "^5.1.0",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^26.0.1",
-        "@rollup/plugin-image": "^3.0.3",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^5.0.7",
-        "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "^11.1.6",
-        "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-        "@testing-library/dom": "^10.4.0",
-        "@types/node": "^22.5.5",
-        "@typescript-eslint/eslint-plugin": "^8.5.0",
-        "@typescript-eslint/parser": "^8.5.0",
-        "autoprefixer": "10.4.20",
-        "chalk": "5.3.0",
-        "clear": "0.1.0",
-        "figlet": "1.7.0",
-        "inquirer": "11.0.1",
-        "live-server": "^1.2.2",
-        "postcss": "^8.4.47",
-        "postcss-import": "^16.1.0",
-        "rollup": "^4.21.3",
-        "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-live-server": "^2.0.0",
-        "rollup-plugin-node-builtins": "^2.1.2",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-string": "^3.0.0",
-        "rollup-plugin-watch-assets": "^1.0.1",
-        "tailwindcss": "^3.4.11"
-      },
-      "bin": {
-        "tspci": "src/cli.js"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/@citolab/tspci-tao": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci-tao/-/tspci-tao-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-oT8GceAr7/FbqreIXyxdsIY7Gkznc/DV68GNqjiXFJeeeZ9liey91tueJNBkfIljlxv+RImc5SrIZq7wBkdNeA==",
-      "dev": true
-    },
-    "pcis/tspci-3d-blocks/node_modules/@citolab/tspci/node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/inquirer": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-      "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.2.1",
-        "@inquirer/prompts": "^6.0.1",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/preact": {
-      "version": "10.6.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "pcis/tspci-3d-blocks/node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "pcis/tspci-color-proportions": {
       "name": "@citolab/pci-verhoudingen",
+      "extraneous": true,
       "dependencies": {
         "@citolab/preact-store": "latest",
         "@react-hook/mouse-position": "^4.1.3",
@@ -15065,198 +14476,6 @@
         "@citolab/tspci": "latest",
         "@citolab/tspci-tao": "latest",
         "autoprefixer": "10.4.13"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/@citolab/preact-store": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-      "license": "MIT",
-      "peerDependencies": {
-        "preact": ">= 10.0.0"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/@citolab/tspci": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/plugin-alias": "^5.1.0",
-        "@rollup/plugin-babel": "^6.0.4",
-        "@rollup/plugin-commonjs": "^26.0.1",
-        "@rollup/plugin-image": "^3.0.3",
-        "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^5.0.7",
-        "@rollup/plugin-terser": "^0.4.4",
-        "@rollup/plugin-typescript": "^11.1.6",
-        "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-        "@testing-library/dom": "^10.4.0",
-        "@types/node": "^22.5.5",
-        "@typescript-eslint/eslint-plugin": "^8.5.0",
-        "@typescript-eslint/parser": "^8.5.0",
-        "autoprefixer": "10.4.20",
-        "chalk": "5.3.0",
-        "clear": "0.1.0",
-        "figlet": "1.7.0",
-        "inquirer": "11.0.1",
-        "live-server": "^1.2.2",
-        "postcss": "^8.4.47",
-        "postcss-import": "^16.1.0",
-        "rollup": "^4.21.3",
-        "rollup-plugin-copy": "^3.5.0",
-        "rollup-plugin-live-server": "^2.0.0",
-        "rollup-plugin-node-builtins": "^2.1.2",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-string": "^3.0.0",
-        "rollup-plugin-watch-assets": "^1.0.1",
-        "tailwindcss": "^3.4.11"
-      },
-      "bin": {
-        "tspci": "src/cli.js"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/@citolab/tspci-tao": {
-      "version": "2.5.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@citolab/tspci-tao/-/tspci-tao-2.5.1-alpha.0.tgz",
-      "integrity": "sha512-oT8GceAr7/FbqreIXyxdsIY7Gkznc/DV68GNqjiXFJeeeZ9liey91tueJNBkfIljlxv+RImc5SrIZq7wBkdNeA==",
-      "dev": true
-    },
-    "pcis/tspci-color-proportions/node_modules/@citolab/tspci/node_modules/autoprefixer": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.23.3",
-        "caniuse-lite": "^1.0.30001646",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/inquirer": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-      "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.2.1",
-        "@inquirer/prompts": "^6.0.1",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/preact": {
-      "version": "10.6.4",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "pcis/tspci-color-proportions/node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     }
   },
@@ -15533,139 +14752,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@citolab/pci-verhoudingen": {
-      "version": "file:pcis/tspci-color-proportions",
-      "requires": {
-        "@citolab/preact-store": "latest",
-        "@citolab/tspci": "latest",
-        "@citolab/tspci-tao": "latest",
-        "@react-hook/mouse-position": "^4.1.3",
-        "autoprefixer": "10.4.13",
-        "preact": "10.6.4"
-      },
-      "dependencies": {
-        "@citolab/preact-store": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-          "requires": {}
-        },
-        "@citolab/tspci": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-          "dev": true,
-          "requires": {
-            "@rollup/plugin-alias": "^5.1.0",
-            "@rollup/plugin-babel": "^6.0.4",
-            "@rollup/plugin-commonjs": "^26.0.1",
-            "@rollup/plugin-image": "^3.0.3",
-            "@rollup/plugin-json": "^6.1.0",
-            "@rollup/plugin-node-resolve": "^15.2.3",
-            "@rollup/plugin-replace": "^5.0.7",
-            "@rollup/plugin-terser": "^0.4.4",
-            "@rollup/plugin-typescript": "^11.1.6",
-            "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-            "@testing-library/dom": "^10.4.0",
-            "@types/node": "^22.5.5",
-            "@typescript-eslint/eslint-plugin": "^8.5.0",
-            "@typescript-eslint/parser": "^8.5.0",
-            "autoprefixer": "10.4.20",
-            "chalk": "5.3.0",
-            "clear": "0.1.0",
-            "figlet": "1.7.0",
-            "inquirer": "11.0.1",
-            "live-server": "^1.2.2",
-            "postcss": "^8.4.47",
-            "postcss-import": "^16.1.0",
-            "rollup": "^4.21.3",
-            "rollup-plugin-copy": "^3.5.0",
-            "rollup-plugin-live-server": "^2.0.0",
-            "rollup-plugin-node-builtins": "^2.1.2",
-            "rollup-plugin-node-globals": "^1.4.0",
-            "rollup-plugin-postcss": "^4.0.2",
-            "rollup-plugin-string": "^3.0.0",
-            "rollup-plugin-watch-assets": "^1.0.1",
-            "tailwindcss": "^3.4.11"
-          },
-          "dependencies": {
-            "autoprefixer": {
-              "version": "10.4.20",
-              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-              "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-              "dev": true,
-              "requires": {
-                "browserslist": "^4.23.3",
-                "caniuse-lite": "^1.0.30001646",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.1",
-                "postcss-value-parser": "^4.2.0"
-              }
-            }
-          }
-        },
-        "@citolab/tspci-tao": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci-tao/-/tspci-tao-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-oT8GceAr7/FbqreIXyxdsIY7Gkznc/DV68GNqjiXFJeeeZ9liey91tueJNBkfIljlxv+RImc5SrIZq7wBkdNeA==",
-          "dev": true
-        },
-        "autoprefixer": {
-          "version": "10.4.13",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-          "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.21.4",
-            "caniuse-lite": "^1.0.30001426",
-            "fraction.js": "^4.2.0",
-            "normalize-range": "^0.1.2",
-            "picocolors": "^1.0.0",
-            "postcss-value-parser": "^4.2.0"
-          }
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-          "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-          "dev": true,
-          "requires": {
-            "@inquirer/core": "^9.2.1",
-            "@inquirer/prompts": "^6.0.1",
-            "@inquirer/type": "^2.0.0",
-            "@types/mute-stream": "^0.0.4",
-            "ansi-escapes": "^4.3.2",
-            "mute-stream": "^1.0.0",
-            "run-async": "^3.0.0",
-            "rxjs": "^7.8.1"
-          }
-        },
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-          "dev": true
-        },
-        "preact": {
-          "version": "10.6.4",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-          "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
-        },
-        "run-async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-          "dev": true
-        }
-      }
-    },
     "@citolab/preact-store": {
       "version": "file:lib/preact-store",
       "requires": {
@@ -15741,145 +14827,18 @@
         }
       }
     },
-    "@citolab/tspci-3d-blocks": {
-      "version": "file:pcis/tspci-3d-blocks",
-      "requires": {
-        "@citolab/preact-store": "latest",
-        "@citolab/tspci": "latest",
-        "@citolab/tspci-tao": "latest",
-        "@types/three": "^0.136.0",
-        "autoprefixer": "10.4.13",
-        "preact": "10.6.4",
-        "three": "^0.136.0",
-        "three-orbitcontrols": "^2.110.3"
-      },
-      "dependencies": {
-        "@citolab/preact-store": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-          "requires": {}
-        },
-        "@citolab/tspci": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-          "dev": true,
-          "requires": {
-            "@rollup/plugin-alias": "^5.1.0",
-            "@rollup/plugin-babel": "^6.0.4",
-            "@rollup/plugin-commonjs": "^26.0.1",
-            "@rollup/plugin-image": "^3.0.3",
-            "@rollup/plugin-json": "^6.1.0",
-            "@rollup/plugin-node-resolve": "^15.2.3",
-            "@rollup/plugin-replace": "^5.0.7",
-            "@rollup/plugin-terser": "^0.4.4",
-            "@rollup/plugin-typescript": "^11.1.6",
-            "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-            "@testing-library/dom": "^10.4.0",
-            "@types/node": "^22.5.5",
-            "@typescript-eslint/eslint-plugin": "^8.5.0",
-            "@typescript-eslint/parser": "^8.5.0",
-            "autoprefixer": "10.4.20",
-            "chalk": "5.3.0",
-            "clear": "0.1.0",
-            "figlet": "1.7.0",
-            "inquirer": "11.0.1",
-            "live-server": "^1.2.2",
-            "postcss": "^8.4.47",
-            "postcss-import": "^16.1.0",
-            "rollup": "^4.21.3",
-            "rollup-plugin-copy": "^3.5.0",
-            "rollup-plugin-live-server": "^2.0.0",
-            "rollup-plugin-node-builtins": "^2.1.2",
-            "rollup-plugin-node-globals": "^1.4.0",
-            "rollup-plugin-postcss": "^4.0.2",
-            "rollup-plugin-string": "^3.0.0",
-            "rollup-plugin-watch-assets": "^1.0.1",
-            "tailwindcss": "^3.4.11"
-          },
-          "dependencies": {
-            "autoprefixer": {
-              "version": "10.4.20",
-              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-              "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-              "dev": true,
-              "requires": {
-                "browserslist": "^4.23.3",
-                "caniuse-lite": "^1.0.30001646",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.1",
-                "postcss-value-parser": "^4.2.0"
-              }
-            }
-          }
-        },
-        "@citolab/tspci-tao": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci-tao/-/tspci-tao-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-oT8GceAr7/FbqreIXyxdsIY7Gkznc/DV68GNqjiXFJeeeZ9liey91tueJNBkfIljlxv+RImc5SrIZq7wBkdNeA==",
-          "dev": true
-        },
-        "autoprefixer": {
-          "version": "10.4.13",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-          "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.21.4",
-            "caniuse-lite": "^1.0.30001426",
-            "fraction.js": "^4.2.0",
-            "normalize-range": "^0.1.2",
-            "picocolors": "^1.0.0",
-            "postcss-value-parser": "^4.2.0"
-          }
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-          "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-          "dev": true,
-          "requires": {
-            "@inquirer/core": "^9.2.1",
-            "@inquirer/prompts": "^6.0.1",
-            "@inquirer/type": "^2.0.0",
-            "@types/mute-stream": "^0.0.4",
-            "ansi-escapes": "^4.3.2",
-            "mute-stream": "^1.0.0",
-            "run-async": "^3.0.0",
-            "rxjs": "^7.8.1"
-          }
-        },
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-          "dev": true
-        },
-        "preact": {
-          "version": "10.6.4",
-          "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
-          "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
-        },
-        "run-async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-          "dev": true
-        }
-      }
-    },
     "@citolab/tspci-qbci": {
       "version": "file:lib/tspci-qbci",
       "requires": {
-        "archiver": "^7.0.1"
+        "archiver": "^7.0.1",
+        "chalk": "5.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+        }
       }
     },
     "@citolab/tspci-tao": {
@@ -16965,35 +15924,6 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
     },
-    "@react-hook/event": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
-      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
-      "requires": {}
-    },
-    "@react-hook/latest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
-      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "requires": {}
-    },
-    "@react-hook/mouse-position": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/mouse-position/-/mouse-position-4.1.3.tgz",
-      "integrity": "sha512-+N4X75CmFiZVEySVmz54MkHk68FqKbbBG2rMCSbGSCCFdypV7rAHiatZwx9Ruq/XfQ01XCxBPaLNMiW69mY19Q==",
-      "requires": {
-        "@react-hook/event": "^1.2.6",
-        "@react-hook/throttle": "^2.2.0"
-      }
-    },
-    "@react-hook/throttle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
-      "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
-      "requires": {
-        "@react-hook/latest": "^1.0.2"
-      }
-    },
     "@rollup/plugin-alias": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
@@ -17416,12 +16346,6 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
-    },
-    "@types/three": {
-      "version": "0.136.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
-      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg==",
-      "dev": true
     },
     "@types/wrap-ansi": {
       "version": "3.0.0",
@@ -19178,87 +18102,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
-    },
-    "demo-pci": {
-      "version": "file:pcis/demoPCI",
-      "requires": {
-        "@citolab/tspci": "latest"
-      },
-      "dependencies": {
-        "@citolab/tspci": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.2.tgz",
-          "integrity": "sha512-y+YyOv4J9j5tEgL2eIfTxmlo8i9ucJ4aA+Hnxjj5jkc9fq6mSFSjSYX/W91VUOcgE6E3ge2hNm8oi44Mx1gTzQ==",
-          "dev": true,
-          "requires": {
-            "@rollup/plugin-alias": "^5.1.0",
-            "@rollup/plugin-babel": "^6.0.4",
-            "@rollup/plugin-commonjs": "^26.0.1",
-            "@rollup/plugin-image": "^3.0.3",
-            "@rollup/plugin-json": "^6.1.0",
-            "@rollup/plugin-node-resolve": "^15.2.3",
-            "@rollup/plugin-replace": "^5.0.7",
-            "@rollup/plugin-terser": "^0.4.4",
-            "@rollup/plugin-typescript": "^11.1.6",
-            "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-            "@testing-library/dom": "^10.4.0",
-            "@types/node": "^22.5.5",
-            "@typescript-eslint/eslint-plugin": "^8.5.0",
-            "@typescript-eslint/parser": "^8.5.0",
-            "autoprefixer": "10.4.20",
-            "chalk": "5.3.0",
-            "clear": "0.1.0",
-            "figlet": "1.7.0",
-            "inquirer": "11.0.1",
-            "live-server": "^1.2.2",
-            "postcss": "^8.4.47",
-            "postcss-import": "^16.1.0",
-            "rollup": "^4.21.3",
-            "rollup-plugin-copy": "^3.5.0",
-            "rollup-plugin-live-server": "^2.0.0",
-            "rollup-plugin-node-builtins": "^2.1.2",
-            "rollup-plugin-node-globals": "^1.4.0",
-            "rollup-plugin-postcss": "^4.0.2",
-            "rollup-plugin-string": "^3.0.0",
-            "rollup-plugin-watch-assets": "^1.0.1",
-            "tailwindcss": "^3.4.11"
-          }
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-          "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-          "dev": true,
-          "requires": {
-            "@inquirer/core": "^9.2.1",
-            "@inquirer/prompts": "^6.0.1",
-            "@inquirer/type": "^2.0.0",
-            "@types/mute-stream": "^0.0.4",
-            "ansi-escapes": "^4.3.2",
-            "mute-stream": "^1.0.0",
-            "run-async": "^3.0.0",
-            "rxjs": "^7.8.1"
-          }
-        },
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-          "dev": true
-        },
-        "run-async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-          "dev": true
-        }
-      }
     },
     "depd": {
       "version": "2.0.0",
@@ -22136,15 +20979,6 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -22696,151 +21530,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "my-pci-three": {
-      "version": "file:pcis/myPciThree",
-      "requires": {
-        "@citolab/preact-store": "latest",
-        "@citolab/tspci": "latest",
-        "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-        "autoprefixer": "10.4.14",
-        "postcss-import": "^15.1.0",
-        "preact": "^10.13.2",
-        "tailwindcss": "^3.3.2"
-      },
-      "dependencies": {
-        "@citolab/preact-store": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/preact-store/-/preact-store-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-FrHjar5EsaTEsr9WkDydKtYyRv8/8ChykES3/2tSEgKZry0zxmjO9t4tdObnORcwDNd8FcEjvaHdVwCaPHlNww==",
-          "requires": {}
-        },
-        "@citolab/tspci": {
-          "version": "2.5.1-alpha.0",
-          "resolved": "https://registry.npmjs.org/@citolab/tspci/-/tspci-2.5.1-alpha.0.tgz",
-          "integrity": "sha512-mjX5jmaENgfjG3RuyauHqNl4waIVpNHXYaNnsnikYhLGWrhw1SEWET3t8t6r4pbHympLyaJDl6r+XrQZK1hk6Q==",
-          "dev": true,
-          "requires": {
-            "@rollup/plugin-alias": "^5.1.0",
-            "@rollup/plugin-babel": "^6.0.4",
-            "@rollup/plugin-commonjs": "^26.0.1",
-            "@rollup/plugin-image": "^3.0.3",
-            "@rollup/plugin-json": "^6.1.0",
-            "@rollup/plugin-node-resolve": "^15.2.3",
-            "@rollup/plugin-replace": "^5.0.7",
-            "@rollup/plugin-terser": "^0.4.4",
-            "@rollup/plugin-typescript": "^11.1.6",
-            "@tailwindcss/nesting": "0.0.0-insiders.565cd3e",
-            "@testing-library/dom": "^10.4.0",
-            "@types/node": "^22.5.5",
-            "@typescript-eslint/eslint-plugin": "^8.5.0",
-            "@typescript-eslint/parser": "^8.5.0",
-            "autoprefixer": "10.4.20",
-            "chalk": "5.3.0",
-            "clear": "0.1.0",
-            "figlet": "1.7.0",
-            "inquirer": "11.0.1",
-            "live-server": "^1.2.2",
-            "postcss": "^8.4.47",
-            "postcss-import": "^16.1.0",
-            "rollup": "^4.21.3",
-            "rollup-plugin-copy": "^3.5.0",
-            "rollup-plugin-live-server": "^2.0.0",
-            "rollup-plugin-node-builtins": "^2.1.2",
-            "rollup-plugin-node-globals": "^1.4.0",
-            "rollup-plugin-postcss": "^4.0.2",
-            "rollup-plugin-string": "^3.0.0",
-            "rollup-plugin-watch-assets": "^1.0.1",
-            "tailwindcss": "^3.4.11"
-          },
-          "dependencies": {
-            "autoprefixer": {
-              "version": "10.4.20",
-              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
-              "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
-              "dev": true,
-              "requires": {
-                "browserslist": "^4.23.3",
-                "caniuse-lite": "^1.0.30001646",
-                "fraction.js": "^4.3.7",
-                "normalize-range": "^0.1.2",
-                "picocolors": "^1.0.1",
-                "postcss-value-parser": "^4.2.0"
-              }
-            },
-            "postcss-import": {
-              "version": "16.1.0",
-              "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-              "integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-              "dev": true,
-              "requires": {
-                "postcss-value-parser": "^4.0.0",
-                "read-cache": "^1.0.0",
-                "resolve": "^1.1.7"
-              }
-            }
-          }
-        },
-        "autoprefixer": {
-          "version": "10.4.14",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-          "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.21.5",
-            "caniuse-lite": "^1.0.30001464",
-            "fraction.js": "^4.2.0",
-            "normalize-range": "^0.1.2",
-            "picocolors": "^1.0.0",
-            "postcss-value-parser": "^4.2.0"
-          }
-        },
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-11.0.1.tgz",
-          "integrity": "sha512-G+GdcKg7AaWER6H3UuccHkDZSJYxE1x12V2AbmJQNY5/WYSBVEDip1nDy0yoQQz21Qm+CscYEXw09lG6OGqTeA==",
-          "dev": true,
-          "requires": {
-            "@inquirer/core": "^9.2.1",
-            "@inquirer/prompts": "^6.0.1",
-            "@inquirer/type": "^2.0.0",
-            "@types/mute-stream": "^0.0.4",
-            "ansi-escapes": "^4.3.2",
-            "mute-stream": "^1.0.0",
-            "run-async": "^3.0.0",
-            "rxjs": "^7.8.1"
-          }
-        },
-        "mute-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-          "dev": true
-        },
-        "postcss-import": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-          "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.0.0",
-            "read-cache": "^1.0.0",
-            "resolve": "^1.1.7"
-          }
-        },
-        "run-async": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-          "dev": true
-        }
-      }
     },
     "mz": {
       "version": "2.7.0",
@@ -23984,7 +22673,8 @@
     "preact": {
       "version": "10.24.0",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.0.tgz",
-      "integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw=="
+      "integrity": "sha512-aK8Cf+jkfyuZ0ZZRG9FbYqwmEiGQ4y/PUO4SuTWoyWL244nZZh7bd5h2APd4rSNDYTBNghg1L+5iJN3Skxtbsw==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -24165,15 +22855,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "react-is": {
       "version": "18.3.1",
@@ -25691,17 +24372,6 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
-    },
-    "three": {
-      "version": "0.136.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
-      "integrity": "sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A=="
-    },
-    "three-orbitcontrols": {
-      "version": "2.110.3",
-      "resolved": "https://registry.npmjs.org/three-orbitcontrols/-/three-orbitcontrols-2.110.3.tgz",
-      "integrity": "sha512-BNNbksJwbN3/MmT0X/gjz5ZCchm7bjk26SUdtJYRxfEYjDfkb/0PeUTHE/KuyJ5vb/owK3mojyy3vcqDx99sRA==",
-      "requires": {}
     },
     "through": {
       "version": "2.3.8",


### PR DESCRIPTION
Added a check and a warning if bundled javascript filesize goes over 500kb (this will result in error in the Facet player)

Added support for using the native CES.getMedia() function
- all media files from the assets folder in your root will be copied to .ref/media
- all found media files will be added in an array  .ref/json/manifes.json as media property
- added chalk for some nice warning colors in cli mesages